### PR TITLE
fix: fix package.json, README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i chrome-cookie
 
 const ChromeCookie = require('chrome-cookie');
 
-const cookie = await ChromeCookie.getCookie('https://github.com');
+const cookie = await new ChromeCookie().getCookie('https://github.com');
 console.log(cookie);
 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "index.js",
-    "lib/"
+    "lib/",
+    "cookie.json"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
- The files field in package.json specifies what files or diretories will be download when the command npm install take effects.So I think should add cookie.json into it.

- Accounding to the source code，Chrome should be an instance invoked by new keyword. Then，the instance can access to the prototype.